### PR TITLE
Fixing inconsistent versions, using 2.5.0

### DIFF
--- a/mempool/Chart.yaml
+++ b/mempool/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "v2.4.0"
+appVersion: "v2.5.0"
 description: A Helm chart for mempool
 name: mempool
-version: 1.0.0
+version: 1.0.1
 dependencies:
 - name: mariadb
   version: "13.1.3"

--- a/mempool/README.md
+++ b/mempool/README.md
@@ -1,6 +1,6 @@
 # mempool
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: v2.4.0](https://img.shields.io/badge/AppVersion-v2.4.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: v2.5.0](https://img.shields.io/badge/AppVersion-v2.5.0-informational?style=flat-square)
 
 A Helm chart for mempool
 
@@ -28,7 +28,7 @@ A Helm chart for mempool
 | backend.fullnameOverride | string | `""` |  |
 | backend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | backend.image.repository | string | `"mempool/backend"` |  |
-| backend.image.tag | string | `"v2.4.0"` |  |
+| backend.image.tag | string | `"v2.5.0"` |  |
 | backend.imagePullSecrets | list | `[]` |  |
 | backend.mempoolBackend.type | string | `"none"` |  |
 | backend.nameOverride | string | `""` |  |

--- a/mempool/values.yaml
+++ b/mempool/values.yaml
@@ -149,7 +149,7 @@ frontend:
 backend:
   image:
     repository: mempool/backend
-    tag: v2.4.0
+    tag: v2.5.0
     pullPolicy: IfNotPresent
 
   strategyType: Recreate


### PR DESCRIPTION
Found inconsistency with versions. Backend was still using 2.4.0. Fixed and rev'd chart version to `1.0.1`.