### PR TITLE
[bitcoind] Remove runAsNonRoot

### DIFF
--- a/charts/bitcoind/Chart.yaml
+++ b/charts/bitcoind/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v25.0"
 description: A Helm chart for bitcoin-core
 name: bitcoind
-version: 1.0.1
+version: 1.0.2

--- a/charts/bitcoind/README.md
+++ b/charts/bitcoind/README.md
@@ -1,6 +1,6 @@
 # bitcoind
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: v25.0](https://img.shields.io/badge/AppVersion-v25.0-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: v25.0](https://img.shields.io/badge/AppVersion-v25.0-informational?style=flat-square)
 
 A Helm chart for bitcoin-core
 
@@ -35,7 +35,6 @@ A Helm chart for bitcoin-core
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
-| securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | service.annotations | object | `{}` |  |
 | service.enableP2p | bool | `true` |  |

--- a/charts/bitcoind/values.yaml
+++ b/charts/bitcoind/values.yaml
@@ -73,7 +73,6 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-  runAsNonRoot: true
   allowPrivilegeEscalation: false
   seccompProfile:
     type: RuntimeDefault


### PR DESCRIPTION
With `runAsNonRoot: true` set, was seeing:
```
Error: container has runAsNonRoot and image has non-numeric user (bitcoind), cannot verify user is non-root (pod: "bitcoind-88589bc66-bq75q_bitcoin(e7fe104d-0bed-45f4-b481-18b1a511da61)", container: bitcoind)
```
Might need to fork or fix this upstream somehow. For now, reverting.