### PR TITLE
[tor] Re-version chart and remove runAsNonRoot

### DIFF
--- a/charts/tor/Chart.yaml
+++ b/charts/tor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "0.4.7.7"
+appVersion: "0.4.7.13"
 description: Tor helm chart. The container can be started as middle(guard)- , bridge- , exit-relay or as proxy exposing only the Socks5 Port per default when running.
 name: tor
 type: application
-version: 0.4.7
+version: 1.0.1

--- a/charts/tor/README.md
+++ b/charts/tor/README.md
@@ -1,6 +1,6 @@
 # tor
 
-![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.7.7](https://img.shields.io/badge/AppVersion-0.4.7.7-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.7.13](https://img.shields.io/badge/AppVersion-0.4.7.13-informational?style=flat-square)
 
 Tor helm chart. The container can be started as middle(guard)- , bridge- , exit-relay or as proxy exposing only the Socks5 Port per default when running.
 
@@ -35,7 +35,6 @@ Tor helm chart. The container can be started as middle(guard)- , bridge- , exit-
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
-| securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | service.annotations | object | `{}` |  |
 | service.enableController | bool | `true` |  |

--- a/charts/tor/values.yaml
+++ b/charts/tor/values.yaml
@@ -63,7 +63,6 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-  runAsNonRoot: true
   allowPrivilegeEscalation: false
   seccompProfile:
     type: RuntimeDefault


### PR DESCRIPTION
- Decoupling the chart version from the appVersion.
- Removing runAsNonRoot because:
```
Error: container has runAsNonRoot and image has non-numeric user (toruser), cannot verify user is non-root (pod: "tor-1-59cc967cc5-t8skk_tor(27d395e6-faaf-4500-9742-2f3470eec8ab)", container: tor)
```