### PR TITLE
[lndhub] Re-version, redis dependency version update, default redis replica count to 2

### DIFF
--- a/charts/lndhub/Chart.lock
+++ b/charts/lndhub/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 18.0.4
-digest: sha256:c4e92231342b67a7cdd8473f6c0f2b9c25fcab28914b51837daaca57b17161ae
-generated: "2023-09-12T17:32:30.324471-04:00"
+  version: 18.1.2
+digest: sha256:29ea26ab6443c5eb7c9c06894db1e6117502b84c77722cef5473bba129e2ac3f
+generated: "2023-10-07T10:22:27.289172-04:00"

--- a/charts/lndhub/Chart.yaml
+++ b/charts/lndhub/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: lndhub
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.0
+version: 0.1.1
 appVersion: v1.4.1
 
 dependencies:
   - name: redis
-    version: 18.0.4
+    version: 18.1.2
     repository: https://charts.bitnami.com/bitnami

--- a/charts/lndhub/README.md
+++ b/charts/lndhub/README.md
@@ -1,6 +1,6 @@
 # lndhub
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.1](https://img.shields.io/badge/AppVersion-v1.4.1-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.1](https://img.shields.io/badge/AppVersion-v1.4.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -8,7 +8,7 @@ A Helm chart for Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | redis | 18.0.4 |
+| https://charts.bitnami.com/bitnami | redis | 18.1.2 |
 
 ## Values
 
@@ -50,6 +50,7 @@ A Helm chart for Kubernetes
 | persistence.size | string | `"1Gi"` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1001` |  |
+| redis.replica.replicaCount | int | `2` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |

--- a/charts/lndhub/values.yaml
+++ b/charts/lndhub/values.yaml
@@ -5,6 +5,11 @@ global:
   redis:
     password: sensitivepassword
 
+redis:
+  # redis replica count
+  replica:
+    replicaCount: 2
+
 config:
   redis:
     port: 6379


### PR DESCRIPTION
- Re-version to 0.1.0 style
- Redis dependency version update (`18.0.4` -> `18.1.2`)
- Default redis replica count to 2 (instead of 3)