### PR TITLE
[bitcoin-core] Internal reference renaming

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "charts/bitcoind"
+    directory: "charts/bitcoin-core"
     schedule:
       interval: "daily"
 

--- a/charts/bitcoin-core/Chart.yaml
+++ b/charts/bitcoin-core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v25.0"
 description: A Helm chart for bitcoin-core
 name: bitcoin-core
-version: 0.1.3
+version: 0.1.4

--- a/charts/bitcoin-core/README.md
+++ b/charts/bitcoin-core/README.md
@@ -18,7 +18,7 @@ A Helm chart for bitcoin-core
 | cookiePersistence.tls | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"lncm/bitcoind"` |  |
+| image.repository | string | `"lncm/bitcoin-core"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/bitcoin-core/README.md
+++ b/charts/bitcoin-core/README.md
@@ -1,6 +1,6 @@
 # bitcoin-core
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: v25.0](https://img.shields.io/badge/AppVersion-v25.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: v25.0](https://img.shields.io/badge/AppVersion-v25.0-informational?style=flat-square)
 
 A Helm chart for bitcoin-core
 
@@ -18,7 +18,7 @@ A Helm chart for bitcoin-core
 | cookiePersistence.tls | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"lncm/bitcoin-core"` |  |
+| image.repository | string | `"lncm/bitcoind"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/bitcoin-core/templates/_helpers.tpl
+++ b/charts/bitcoin-core/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "bitcoind.name" -}}
+{{- define "bitcoin-core.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -11,7 +11,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "bitcoind.fullname" -}}
+{{- define "bitcoin-core.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -27,16 +27,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "bitcoind.chart" -}}
+{{- define "bitcoin-core.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
-{{- define "bitcoind.labels" -}}
-app.kubernetes.io/name: {{ include "bitcoind.name" . }}
-helm.sh/chart: {{ include "bitcoind.chart" . }}
+{{- define "bitcoin-core.labels" -}}
+app.kubernetes.io/name: {{ include "bitcoin-core.name" . }}
+helm.sh/chart: {{ include "bitcoin-core.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
@@ -47,9 +47,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "bitcoind.serviceAccountName" -}}
+{{- define "bitcoin-core.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "bitcoind.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "bitcoin-core.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
@@ -59,7 +59,7 @@ Create the name of the service account to use
 {{/*
 Allow the release namespace to be overridden for multi-namespace deployments in combined charts
 */}}
-{{- define "bitcoind.namespace" -}}
+{{- define "bitcoin-core.namespace" -}}
   {{- if .Values.namespaceOverride -}}
     {{- .Values.namespaceOverride -}}
   {{- else -}}
@@ -70,7 +70,7 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{/*
 Return the appropriate apiVersion for ingress.
 */}}
-{{- define "bitcoind.ingress.apiVersion" -}}
+{{- define "bitcoin-core.ingress.apiVersion" -}}
   {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
       {{- print "networking.k8s.io/v1" -}}
   {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
@@ -82,18 +82,18 @@ Return the appropriate apiVersion for ingress.
 {{/*
 Return if ingress is stable.
 */}}
-{{- define "bitcoind.ingress.isStable" -}}
-  {{- eq (include "bitcoind.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- define "bitcoin-core.ingress.isStable" -}}
+  {{- eq (include "bitcoin-core.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
 {{- end -}}
 {{/*
 Return if ingress supports ingressClassName.
 */}}
-{{- define "bitcoind.ingress.supportsIngressClassName" -}}
-  {{- or (eq (include "bitcoind.ingress.isStable" .) "true") (and (eq (include "bitcoind.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- define "bitcoin-core.ingress.supportsIngressClassName" -}}
+  {{- or (eq (include "bitcoin-core.ingress.isStable" .) "true") (and (eq (include "bitcoin-core.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
 {{- end -}}
 {{/*
 Return if ingress supports pathType.
 */}}
-{{- define "bitcoind.ingress.supportsPathType" -}}
-  {{- or (eq (include "bitcoind.ingress.isStable" .) "true") (and (eq (include "bitcoind.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- define "bitcoin-core.ingress.supportsPathType" -}}
+  {{- or (eq (include "bitcoin-core.ingress.isStable" .) "true") (and (eq (include "bitcoin-core.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
 {{- end -}}

--- a/charts/bitcoin-core/templates/deployment.yaml
+++ b/charts/bitcoin-core/templates/deployment.yaml
@@ -2,22 +2,22 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "bitcoind.name" . }}
-    chart: {{ template "bitcoind.chart" . }}
+    app: {{ template "bitcoin-core.name" . }}
+    chart: {{ template "bitcoin-core.chart" . }}
     heritage: {{ .Release.Service }}
     {{ .Values.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: bitcoin-core
 
     {{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
     {{- end }}
-  name: {{ template "bitcoind.fullname" . }}
+  name: {{ template "bitcoin-core.fullname" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
     type: {{ .Values.strategyType }}
   selector:
     matchLabels:
-      app: {{ template "bitcoind.name" . }}
+      app: {{ template "bitcoin-core.name" . }}
     {{- if .Values.useComponentLabel }}
       {{ .Values.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: bitcoin-core
     {{- end }}
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       {{- end }}
       labels:
-        app: {{ template "bitcoind.name" . }}
+        app: {{ template "bitcoin-core.name" . }}
         component: "{{ .Values.name }}"
         {{ .Values.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: bitcoin-core
         {{- if .Values.podLabels }}
@@ -44,7 +44,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ template "bitcoind.serviceAccountName" . }}
+      serviceAccountName: {{ template "bitcoin-core.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: 300
@@ -128,7 +128,7 @@ spec:
           type: Directory
         {{- else }}
         persistentVolumeClaim:
-          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "bitcoind.fullname" . }}{{- end }}
+          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "bitcoin-core.fullname" . }}{{- end }}
         {{- end }}
       {{- else }}
         emptyDir: {}
@@ -141,7 +141,7 @@ spec:
           type: Directory
         {{- else }}
         persistentVolumeClaim:
-          claimName: {{ if .Values.cookiePersistence.existingClaim }}{{ .Values.cookiePersistence.existingClaim }}{{- else }}{{ template "bitcoind.fullname" . }}-authcookie{{- end }}
+          claimName: {{ if .Values.cookiePersistence.existingClaim }}{{ .Values.cookiePersistence.existingClaim }}{{- else }}{{ template "bitcoin-core.fullname" . }}-authcookie{{- end }}
         {{- end }}
       {{- else }}
         emptyDir: {}

--- a/charts/bitcoin-core/templates/ingress.yaml
+++ b/charts/bitcoin-core/templates/ingress.yaml
@@ -1,19 +1,19 @@
 {{- if .Values.ingress.enabled -}}
-{{- $ingressApiIsStable := eq (include "bitcoind.ingress.isStable" .) "true" -}}
-{{- $ingressSupportsIngressClassName := eq (include "bitcoind.ingress.supportsIngressClassName" .) "true" -}}
-{{- $ingressSupportsPathType := eq (include "bitcoind.ingress.supportsPathType" .) "true" -}}
-{{- $fullName := include "bitcoind.fullname" . -}}
+{{- $ingressApiIsStable := eq (include "bitcoin-core.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "bitcoin-core.ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "bitcoin-core.ingress.supportsPathType" .) "true" -}}
+{{- $fullName := include "bitcoin-core.fullname" . -}}
 {{- $servicePort := .Values.service.tcpPort -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressPathType := .Values.ingress.pathType -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}
-apiVersion: {{ include "bitcoind.ingress.apiVersion" . }}
+apiVersion: {{ include "bitcoin-core.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ template "bitcoind.namespace" . }}
+  namespace: {{ template "bitcoin-core.namespace" . }}
   labels:
-    {{- include "bitcoind.labels" . | nindent 4 }}
+    {{- include "bitcoin-core.labels" . | nindent 4 }}
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}

--- a/charts/bitcoin-core/templates/pvc-authcookie.yaml
+++ b/charts/bitcoin-core/templates/pvc-authcookie.yaml
@@ -3,10 +3,10 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ template "bitcoind.fullname" . }}-authcookie"
+  name: "{{ template "bitcoin-core.fullname" . }}-authcookie"
   labels:
-    app.kubernetes.io/name: {{ include "bitcoind.name" . }}
-    helm.sh/chart: {{ include "bitcoind.chart" . }}
+    app.kubernetes.io/name: {{ include "bitcoin-core.name" . }}
+    helm.sh/chart: {{ include "bitcoin-core.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:

--- a/charts/bitcoin-core/templates/pvc-data.yaml
+++ b/charts/bitcoin-core/templates/pvc-data.yaml
@@ -3,10 +3,10 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "bitcoind.fullname" . }}
+  name: {{ template "bitcoin-core.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "bitcoind.name" . }}
-    helm.sh/chart: {{ include "bitcoind.chart" . }}
+    app.kubernetes.io/name: {{ include "bitcoin-core.name" . }}
+    helm.sh/chart: {{ include "bitcoin-core.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:

--- a/charts/bitcoin-core/templates/service.yaml
+++ b/charts/bitcoin-core/templates/service.yaml
@@ -13,11 +13,11 @@ metadata:
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
-    app: {{ template "bitcoind.name" . }}
-    chart: {{ template "bitcoind.chart" . }}
+    app: {{ template "bitcoin-core.name" . }}
+    chart: {{ template "bitcoin-core.chart" . }}
     component: "{{ .Values.name }}"
     heritage: {{ .Release.Service }}
-  name: {{ template "bitcoind.fullname" . }}
+  name: {{ template "bitcoin-core.fullname" . }}
 spec:
 {{- if not .Values.service.omitClusterIP }}
   {{- with .Values.service.clusterIP }}
@@ -87,7 +87,7 @@ spec:
      {{- end }}
   {{- end }}
   selector:
-    app: {{ template "bitcoind.name" . }}
+    app: {{ template "bitcoin-core.name" . }}
     {{ .Values.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: bitcoin-core
   type: "{{ .Values.service.type }}"
 {{- end }}

--- a/charts/bitcoin-core/templates/serviceaccount.yaml
+++ b/charts/bitcoin-core/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "bitcoind.serviceAccountName" . }}
+  name: {{ template "bitcoin-core.serviceAccountName" . }}
   labels:
-{{ include "bitcoind.labels" . | indent 4 }}
+{{ include "bitcoin-core.labels" . | indent 4 }}
 {{- end -}}

--- a/charts/bitcoin-core/templates/tests/test-connection.yaml
+++ b/charts/bitcoin-core/templates/tests/test-connection.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "bitcoind.fullname" . }}-test-connection"
+  name: "{{ include "bitcoin-core.fullname" . }}-test-connection"
   labels:
-{{ include "bitcoind.labels" . | indent 4 }}
+{{ include "bitcoin-core.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "bitcoind.fullname" . }}:{{ .Values.service.port }}']
+      args:  ['{{ include "bitcoin-core.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never


### PR DESCRIPTION
Renaming internal references from `bitcoind` to `bitcoin-core` for consistency.