### PR TITLE
Renovate for appversion

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+      "config:base"
+    ],
+    "regexManagers": [
+      {
+        "fileMatch": ["(^|/)Chart\\.yaml$"],
+        "matchStrings": [
+          "#\\s?renovate: image=(?<depName>.*?)\\s?appVersion:\\s?\\\"?(?<currentValue>[\\w+\\.\\-]*)"
+        ],
+        "datasourceTemplate": "docker"
+      }
+    ]
+  }

--- a/charts/bitcoind/Chart.yaml
+++ b/charts/bitcoind/Chart.yaml
@@ -1,5 +1,6 @@
-apiVersion: v1
-appVersion: "v25.0"
+apiVersion: v2
 description: A Helm chart for bitcoin-core daemon bitcoind
 name: bitcoind
 version: 0.1.5
+# renovate: image=lncm/bitcoind
+appVersion: "v25.0"

--- a/charts/fulcrum/Chart.yaml
+++ b/charts/fulcrum/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
-appVersion: "v1.9.1"
+type: application
 description: fulcrum helm chart
 name: fulcrum
-type: application
 version: 0.1.1
+# renovate: image=cculianu/fulcrum
+appVersion: "v1.9.1"

--- a/charts/lnd/Chart.yaml
+++ b/charts/lnd/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 name: lnd
-version: 0.1.0
-appVersion: v0.17.0-beta
 description: A golang implementation of a Lightning Network node
+version: 0.1.0
+# renovate: image=lightninglabs/lnd
+appVersion: v0.17.0-beta
 keywords:
   - lnd
   - bitcoin

--- a/charts/lndhub/Chart.yaml
+++ b/charts/lndhub/Chart.yaml
@@ -3,6 +3,7 @@ name: lndhub
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.2
+# renovate: image=bluewalletorganization/lndhub
 appVersion: v1.4.1
 
 dependencies:

--- a/charts/mempool/Chart.yaml
+++ b/charts/mempool/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v2
-appVersion: "v2.5.0"
 description: A Helm chart for mempool
 name: mempool
 version: 0.1.2
+# renovate: image=mempool/frontend
+appVersion: "v2.5.0"
 dependencies:
 - name: mariadb
   version: "13.1.3"

--- a/charts/thunderhub/Chart.yaml
+++ b/charts/thunderhub/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
-appVersion: "v0.13.23"
 description: A Helm chart for thunderhub
 name: thunderhub
 version: 0.1.1
+# renovate: image=apotdevin/thunderhub
+appVersion: "v0.13.23"

--- a/charts/tor/Chart.yaml
+++ b/charts/tor/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
-appVersion: "0.4.7.13"
 description: Tor helm chart. The container can be started as middle(guard)- , bridge- , exit-relay or as proxy exposing only the Socks5 Port per default when running.
 name: tor
 type: application
 version: 0.1.2
+# renovate: image=lncm/tor
+appVersion: "0.4.7.13"


### PR DESCRIPTION
Renovate doesn't natively support rev'ing based on Chart.yaml appVersion. Adding custom regex manager and implementing on a few charts.