### PR TITLE
[fulcrum] Add ingress and refactor ports

### DIFF
--- a/charts/fulcrum/Chart.yaml
+++ b/charts/fulcrum/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 type: application
 description: fulcrum helm chart
 name: fulcrum
-version: 0.1.4
+version: 0.1.5
 # renovate: image=cculianu/fulcrum
 appVersion: "v1.10.0"

--- a/charts/fulcrum/README.md
+++ b/charts/fulcrum/README.md
@@ -1,6 +1,6 @@
 # fulcrum
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.10.0](https://img.shields.io/badge/AppVersion-v1.10.0-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.10.0](https://img.shields.io/badge/AppVersion-v1.10.0-informational?style=flat-square)
 
 fulcrum helm chart
 
@@ -10,11 +10,6 @@ fulcrum helm chart
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | arguments[0] | string | `"/data/config.toml"` |  |
-| certificate.dnsNames[0] | string | `"myelectrumserver.domain.com"` |  |
-| certificate.enabled | bool | `false` |  |
-| certificate.issuerRef.kind | string | `"ClusterIssuer"` |  |
-| certificate.issuerRef.name | string | `"letsencrypt-prod"` |  |
-| certificate.mountCertificate | bool | `true` |  |
 | config | string | `"# Example config: https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf\ndatadir = /data\nbitcoind = bitcoind:8332\nrpcuser = fulcrum\nrpcpassword = hunter1\n#rpccookie = /authcookie/.cookie\n"` |  |
 | cookiePersistence.enabled | bool | `false` |  |
 | cookiePersistence.existingClaim | string | `"bitcoin-core-authcookie"` |  |
@@ -23,6 +18,13 @@ fulcrum helm chart
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"cculianu/fulcrum"` |  |
 | imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.extraPaths | list | `[]` |  |
+| ingress.hosts[0] | string | `"chart-example.local"` |  |
+| ingress.labels | object | `{}` |  |
+| ingress.path | string | `"/"` |  |
+| ingress.pathType | string | `"Prefix"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |
@@ -41,14 +43,17 @@ fulcrum helm chart
 | service.loadBalancerIP | string | `""` |  |
 | service.loadBalancerSourceRanges | list | `[]` |  |
 | service.omitClusterIP | bool | `false` |  |
-| service.ports.ssl | int | `50002` |  |
-| service.ports.tcp | int | `50001` |  |
 | service.sessionAffinity | string | `""` |  |
-| service.targetPorts.ssl | int | `50002` |  |
-| service.targetPorts.tcp | int | `50001` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `nil` |  |
+| ssl.certificate.secretName | string | `"fulcrum-ssl-certificate"` |  |
+| ssl.dnsNames[0] | string | `"myelectrumserver.domain.com"` |  |
+| ssl.enabled | bool | `false` |  |
+| ssl.issuerRef.kind | string | `"ClusterIssuer"` |  |
+| ssl.issuerRef.name | string | `"letsencrypt-prod"` |  |
+| ssl.mountCertificate | bool | `true` |  |
+| ssl.useCertManager | bool | `true` |  |
 | strategyType | string | `"Recreate"` |  |
 | tolerations | list | `[]` |  |
 

--- a/charts/fulcrum/templates/certificate.yaml
+++ b/charts/fulcrum/templates/certificate.yaml
@@ -1,12 +1,12 @@
-{{- if and (.Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate") .Values.certificate.enabled }}
+{{- if and .Values.ssl.enabled .Values.ssl.useCertManager }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ template "fulcrum.fullname" . }}-tls
+  name: {{ template "fulcrum.fullname" . }}-ssl-certificate
 spec:
-  secretName: {{ template "fulcrum.fullname" . }}-secret
+  secretName: {{ .Values.ssl.certificate.secretName }}
   issuerRef:
-    name: {{ .Values.certificate.issuerRef.name }}
-    kind: {{ .Values.certificate.issuerRef.kind }}
-  dnsNames: {{ .Values.certificate.dnsNames }}
+    name: {{ .Values.ssl.issuerRef.name }}
+    kind: {{ .Values.ssl.issuerRef.kind }}
+  dnsNames: {{ .Values.ssl.certificate.dnsNames }}
 {{- end }}

--- a/charts/fulcrum/templates/deployment.yaml
+++ b/charts/fulcrum/templates/deployment.yaml
@@ -62,11 +62,7 @@ spec:
           {{ end }}
           ports:
             - name: tcp
-              containerPort: {{ .Values.service.ports.tcp }}
-              protocol: TCP
-            - name: ssl
-              containerPort: {{ .Values.service.ports.ssl }}
-              protocol: TCP
+              containerPort: {{ .Values.ssl.enabled | ternary 50002 50001 }}
           volumeMounts:
             - name: config
               mountPath: /data/config.toml
@@ -75,12 +71,12 @@ spec:
               name: data
             - mountPath: /authcookie/
               name: authcookie
-            {{- if and .Values.certificate.enabled .Values.certificate.mountCertificate }}
-            - name: tls
+            {{- if and .Values.ssl.enabled .Values.ssl.mountCertificate }}
+            - name: ssl
               mountPath: "/ssl/tls.crt"
               subPath: tls.crt
               readOnly: true
-            - name: tls
+            - name: ssl
               mountPath: "/ssl/tls.key"
               subPath: tls.key
               readOnly: true
@@ -133,8 +129,8 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
-      {{- if and .Values.certificate.enabled .Values.certificate.mountCertificate }}
-      - name: tls
+      {{- if and .Values.ssl.enabled .Values.ssl.mountCertificate }}
+      - name: ssl
         secret:
-          secretName: {{ template "fulcrum.fullname" . }}-secret
+          secretName: {{ .Values.ssl.certificate.secretName }}
       {{- end }}

--- a/charts/fulcrum/templates/ingress.yaml
+++ b/charts/fulcrum/templates/ingress.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ingressApiIsStable := eq (include "fulcrum.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "fulcrum.ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "fulcrum.ingress.supportsPathType" .) "true" -}}
+{{- $fullName := include "fulcrum.fullname" . -}}
+{{- $servicePort := .Values.ssl.enabled | ternary 50002 50001 -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
+{{- $extraPaths := .Values.ingress.extraPaths -}}
+apiVersion: {{ include "fulcrum.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ template "fulcrum.namespace" . }}
+  labels:
+    {{- include "fulcrum.labels" . | nindent 4 }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end -}}
+{{- if .Values.ingress.tls }}
+  tls:
+{{ tpl (toYaml .Values.ingress.tls) $ | indent 4 }}
+{{- end }}
+  rules:
+  {{- if .Values.ingress.hosts  }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ tpl . $}}
+      http:
+        paths:
+{{- if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+{{- end }}
+          - path: {{ $ingressPath }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
+            backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+              {{- end }}
+  {{- end }}
+  {{- else }}
+    - http:
+        paths:
+          - backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $servicePort }}
+              {{- end }}
+            {{- if $ingressPath }}
+            path: {{ $ingressPath }}
+            {{- end }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
+  {{- end -}}
+{{- end }}

--- a/charts/fulcrum/templates/service.yaml
+++ b/charts/fulcrum/templates/service.yaml
@@ -45,13 +45,8 @@ spec:
 {{- end }}
   ports:
     - name: tcp
-      port: {{ .Values.service.ports.tcp }}
-      protocol: TCP
+      port: {{ .Values.ssl.enabled | ternary 50002 50001 }}
       targetPort: tcp
-    - name: ssl
-      port: {{ .Values.service.ports.ssl }}
-      protocol: TCP
-      targetPort: ssl
   selector:
     app: {{ template "fulcrum.name" . }}
     {{ .Values.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: fulcrum

--- a/charts/fulcrum/values.yaml
+++ b/charts/fulcrum/values.yaml
@@ -22,15 +22,19 @@ config: |
   rpcpassword = hunter1
   #rpccookie = /authcookie/.cookie
 
-certificate:
+ssl:
   enabled: false
+  useCertManager: true
   mountCertificate: true
   dnsNames:
     - "myelectrumserver.domain.com"
-
+  
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer
+  
+  certificate:
+    secretName: "fulcrum-ssl-certificate"
 
 arguments:
   - /data/config.toml
@@ -52,6 +56,38 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+
+ingress:
+  enabled: false
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
+  # Values can be templated
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
+  path: /
+
+  # pathType is only for k8s >= 1.1=
+  pathType: Prefix
+
+  hosts:
+    - chart-example.local
+  ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  extraPaths: []
+  # - path: /*
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
+  ## Or for k8s > 1.19
+  # - path: /*
+  #   pathType: Prefix
+  #   backend:
+  #     service:
+  #       name: ssl-redirect
+  #       port:
+  #         name: use-annotation
 
 service:
   enabled: true
@@ -80,14 +116,6 @@ service:
   sessionAffinity: ""
 
   healthCheckNodePort: 0
-
-  ports:
-    tcp: 50001
-    ssl: 50002
-
-  targetPorts:
-    tcp: 50001
-    ssl: 50002
 
   type: ClusterIP
 


### PR DESCRIPTION
- Adds optional ingress. Likely wouldn't use it unless you want to hang fulcrum off of 80 or 443, otherwise you'd probably use a custom entrypoint on 50002 or 50001.
- Refactors ports to clean up and be less confusing.
- Refactors certificate to be more generic and possibly support more options besides cert-manager.