### PR TITLE
[c-lightning] Add secondary persistence for sqlite3 replication

### DIFF
--- a/charts/c-lightning/Chart.yaml
+++ b/charts/c-lightning/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: c-lightning
 description: A specification compliant Lightning Network implementation in C
-version: 0.1.0
+version: 0.1.1
 # renovate: image=elementsproject/lightningd
 appVersion: v24.02-amd64
 keywords:

--- a/charts/c-lightning/README.md
+++ b/charts/c-lightning/README.md
@@ -1,6 +1,6 @@
 # c-lightning
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: v24.02-amd64](https://img.shields.io/badge/AppVersion-v24.02--amd64-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![AppVersion: v24.02-amd64](https://img.shields.io/badge/AppVersion-v24.02--amd64-informational?style=flat-square)
 
 A specification compliant Lightning Network implementation in C
 
@@ -11,7 +11,8 @@ A specification compliant Lightning Network implementation in C
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | arguments | list | `[]` |  |
-| configurationFile.config | string | `"alias=MyNodeAlias\nnetwork=bitcoin\nbitcoin-rpcconnect=bitcoind.bitcoin.svc.cluster.local\nbitcoin-rpcport=8332\nbitcoin-rpcuser=c-lightning\nbitcoin-rpcpassword=aHVudGVyMQ=="` |  |
+| configurationFile.config | string | `"wallet=sqlite3:///root/.lightning/bitcoin/lightningd.sqlite3:/root/backup/lightningd.sqlite3\nalias=MyNodeAlias\nnetwork=bitcoin\nbitcoin-rpcconnect=bitcoind.bitcoin.svc.cluster.local\nbitcoin-rpcport=8332\nbitcoin-rpcuser=c-lightning\nbitcoin-rpcpassword=aHVudGVyMQ=="` |  |
+| extraContainers | list | `[]` |  |
 | extraManifests | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -37,6 +38,9 @@ A specification compliant Lightning Network implementation in C
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | persistence.enabled | bool | `false` |  |
 | persistence.size | string | `"5Gi"` |  |
+| persistenceBackup.accessMode | string | `"ReadWriteOnce"` |  |
+| persistenceBackup.enabled | bool | `false` |  |
+| persistenceBackup.size | string | `"5Gi"` |  |
 | podSecurityContext | object | `{}` |  |
 | resources.limits.memory | string | `"512Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |

--- a/charts/c-lightning/templates/deployment.yaml
+++ b/charts/c-lightning/templates/deployment.yaml
@@ -76,6 +76,11 @@ spec:
             - name: data
               mountPath: /root/.lightning
               subPath: .lightning
+            {{- if .Values.persistenceBackup.enabled }}
+            - name: backup
+              mountPath: /root/backup
+              subPath: backup
+            {{- end }}
             {{- if .Values.configurationFile }}
             - name: config
               mountPath: /root/.lightning/config
@@ -87,6 +92,9 @@ spec:
                 # Make sure we safely quit c-lightning so we don't corrupt
                 # anything
                 command: ["lightning-cli", "stop"]
+        {{- if .Values.extraContainers }}
+        {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- end }}
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
@@ -114,6 +122,13 @@ spec:
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (include "c-lightning.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: backup
+        {{- if .Values.persistenceBackup.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistenceBackup.existingClaim | default (printf "%s-backup" (include "c-lightning.fullname" .)) | quote }}
         {{- else }}
           emptyDir: {}
         {{- end -}}

--- a/charts/c-lightning/templates/pvc-backup.yaml
+++ b/charts/c-lightning/templates/pvc-backup.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.persistenceBackup.enabled (not .Values.persistenceBackup.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "c-lightning.fullname" . }}-backup
+  namespace: {{ template "c-lightning.namespace" . }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app: {{ template "c-lightning.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.persistenceBackup.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistenceBackup.size | quote }}
+{{- if .Values.persistenceBackup.storageClass }}
+{{- if (eq "-" .Values.persistenceBackup.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistenceBackup.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/c-lightning/values.yaml
+++ b/charts/c-lightning/values.yaml
@@ -29,6 +29,7 @@ arguments: []
 # Custom c-lightning configuration file used to override default c-lightning settings
 configurationFile:
   config: |-
+    wallet=sqlite3:///root/.lightning/bitcoin/lightningd.sqlite3:/root/backup/lightningd.sqlite3
     alias=MyNodeAlias
     network=bitcoin
     bitcoin-rpcconnect=bitcoind.bitcoin.svc.cluster.local
@@ -120,7 +121,27 @@ ingress:
     #       port:
     #         name: use-annotation
 
+# This persistence section is used to configure the primary persistent storage for c-lightning (aka .lightning)
 persistence:
+  enabled: false
+  ## database data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 5Gi
+
+# Use persistenceBackup along with db replication described here:
+# https://docs.corelightning.org/docs/advanced-db-backup#sqlite3---walletmainbackup-and-remote-nfs-mount
+# This persistenceBackup will mount a second volume to /root/backup. To utilize this, you could use
+# 
+#   wallet=/root/.lightning/bitcoin/lightningd.sqlite3:/root/backup/lightningd.sqlite3
+# 
+persistenceBackup:
   enabled: false
   ## database data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
@@ -142,6 +163,8 @@ resources:
     cpu: 100m
   limits:
     memory: 512Mi
+
+extraContainers: []
 
 extraManifests: []
 # extraManifests:


### PR DESCRIPTION
Closes https://github.com/bboerst/bitcoin-helm-charts/issues/103

This PR adds a secondary persistent storage option that mounts to /root/backup. The intended purpose is to use built-in CLN db replication by adding configuration like:
```
wallet=sqlite3:///root/.lightning/bitcoin/lightningd.sqlite3:/root/backup/lightningd.sqlite3
```
This way the _main_ `lightningd.sqlite3` db will be handled by `persistence:` and the replica will be handled by `persistenceBackup:`.

In my setup, I'm using local-path-provisioner for the main pvc and an nfs-external-provisioner for the backup storage. This way the db is replicated to an NFS share and periodically backed up. It's still not ideal because the replica on NFS is getting hot-backed-up, but in this scenario 3 different things will all have to fail:

1. Main db failure
2. Replica failure
3. Nightly backup failure

The odds of all 3 failing is not likely, but this will suffice until a more elegant backup strategy can be implemented in the future. Maybe some kind of sidecar running `sqlite3 .backup` on a cron or something.