### PR TITLE
[c-lightning] Version bump to v24.08.1

### DIFF
--- a/charts/c-lightning/Chart.yaml
+++ b/charts/c-lightning/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: c-lightning
 description: A specification compliant Lightning Network implementation in C
-version: 0.1.3
+version: 0.1.4
 # renovate: image=elementsproject/lightningd
-appVersion: v24.08
+appVersion: v24.08.1
 keywords:
   - c-lightning
   - bitcoin

--- a/charts/c-lightning/README.md
+++ b/charts/c-lightning/README.md
@@ -1,6 +1,6 @@
 # c-lightning
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: v24.08](https://img.shields.io/badge/AppVersion-v24.08-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: v24.08.1](https://img.shields.io/badge/AppVersion-v24.08.1-informational?style=flat-square)
 
 A specification compliant Lightning Network implementation in C
 

--- a/charts/c-lightning/templates/configmap.yaml
+++ b/charts/c-lightning/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "c-lightning.fullname" . }}
   namespace: {{ template "c-lightning.namespace" . }}
   labels:
-    app: {{ template "c-lightning.name" . }}
+    app: {{ template "c-lightning.fullname" . }}
     chart: {{ template "c-lightning.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/c-lightning/templates/deployment.yaml
+++ b/charts/c-lightning/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "c-lightning.fullname" . }}
   namespace: {{ template "c-lightning.namespace" . }}
   labels:
-    app: {{ template "c-lightning.name" . }}
+    app: {{ template "c-lightning.fullname" . }}
     chart: {{ template "c-lightning.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -13,14 +13,14 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: {{ template "c-lightning.name" . }}
+      app: {{ template "c-lightning.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
-        app: {{ template "c-lightning.name" . }}
+        app: {{ template "c-lightning.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       {{- if .Values.configurationFile }}

--- a/charts/c-lightning/templates/pvc-backup.yaml
+++ b/charts/c-lightning/templates/pvc-backup.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
-    app: {{ template "c-lightning.name" . }}
+    app: {{ template "c-lightning.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/charts/c-lightning/templates/pvc.yaml
+++ b/charts/c-lightning/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
-    app: {{ template "c-lightning.name" . }}
+    app: {{ template "c-lightning.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/charts/c-lightning/templates/service.yaml
+++ b/charts/c-lightning/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "c-lightning.fullname" . }}
   namespace: {{ template "c-lightning.namespace" . }}
   labels:
-    app: {{ template "c-lightning.name" . }}
+    app: {{ template "c-lightning.fullname" . }}
     chart: {{ template "c-lightning.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -20,5 +20,5 @@ spec:
       targetPort: rest
     {{- end }}
   selector:
-    app: {{ template "c-lightning.name" . }}
+    app: {{ template "c-lightning.fullname" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
- Bumping CLN to v24.08.1 https://github.com/ElementsProject/lightning/releases/tag/v24.08.1
- Making 'app' selector unique to support multiple CLN instances running within the same k8s namespace