### PR TITLE
[bitcoind] v28.0 with additional updates

### DIFF
--- a/charts/bitcoind/Chart.yaml
+++ b/charts/bitcoind/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 description: A Helm chart for bitcoin-core daemon bitcoind
 name: bitcoind
-version: 0.3.3
-# renovate: image=lncm/bitcoind
-appVersion: "v27.1"
+version: 0.3.4
+# renovate: image=bboerst/lncm-bitcoind
+appVersion: "v28.0-amd64"

--- a/charts/bitcoind/README.md
+++ b/charts/bitcoind/README.md
@@ -1,6 +1,6 @@
 # bitcoind
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![AppVersion: v27.1](https://img.shields.io/badge/AppVersion-v27.1-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![AppVersion: v28.0-amd64](https://img.shields.io/badge/AppVersion-v28.0--amd64-informational?style=flat-square)
 
 A Helm chart for bitcoin-core daemon bitcoind
 
@@ -12,14 +12,16 @@ A Helm chart for bitcoin-core daemon bitcoind
 | arguments[0] | string | `"-printtoconsole"` |  |
 | arguments[1] | string | `"-txindex"` |  |
 | arguments[2] | string | `"-disablewallet"` |  |
+| configExternalSecretName | string | `""` |  |
 | cookiePersistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | cookiePersistence.enabled | bool | `false` |  |
 | cookiePersistence.size | string | `"5Mi"` |  |
 | cookiePersistence.tls | list | `[]` |  |
+| extraEnv | object | `{}` |  |
 | extraManifests | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"lncm/bitcoind"` |  |
+| image.repository | string | `"bboerst/lncm-bitcoind"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/bitcoind/templates/deployment.yaml
+++ b/charts/bitcoind/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: {{ .Release.Service }}
     {{ .Values.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: bitcoind
     {{- if .Values.deploymentLabels }}
-{{ toYaml .Values.deploymentLabels | indent 4 }}
+    {{- toYaml .Values.deploymentLabels | nindent 4 }}
     {{- end }}
   name: {{ template "bitcoind.fullname" . }}
 spec:
@@ -53,14 +53,21 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            {{- if .Values.configExternalSecretName }}
+            - -conf=/config/bitcoin.conf
+            {{- end }}
             {{- range .Values.arguments }}
             - {{ . }}
             {{- end }}
           env:
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
+          {{- range $key, $value := .Values.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           ports:
             {{- if .Values.service.enableRpc }}
             - name: rpc
@@ -72,9 +79,16 @@ spec:
               containerPort: {{ .Values.service.ports.p2p }}
               protocol: TCP
             {{- end }}
+            {{- if .Values.service.ports.tcp }}
             {{- range $port := .Values.service.ports.tcp }}
             - name: "{{ $port }}-tcp"
               containerPort: {{ $port }}
+              protocol: TCP
+            {{- end }}
+            {{- else }}
+            # Default fallback
+            - name: tcp-default
+              containerPort: 8333
               protocol: TCP
             {{- end }}
             {{- range $port := .Values.service.ports.udp }}
@@ -101,6 +115,11 @@ spec:
           volumeMounts:
             - mountPath: /data/.bitcoin/
               name: data
+            {{- if .Values.configExternalSecretName }}
+            - mountPath: /config
+              name: config-secret
+              readOnly: true
+            {{- end }}
             {{- if .Values.cookiePersistence.enabled }}
             - mountPath: /authcookie/
               name: authcookie
@@ -119,14 +138,19 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.persistence.enabled }}
-  {{- if .Values.persistence.hostPath }}
-  volumes:
-    - name: data
-      hostPath:
-        path: {{ .Values.persistence.hostPath }}
-        type: DirectoryOrCreate
-  {{- else }}
+      volumes:
+      {{- if .Values.configExternalSecretName }}
+        - name: config-secret
+          secret:
+            secretName: {{ .Values.configExternalSecretName }}
+      {{- end }}
+      {{- if .Values.persistence.enabled }}
+      {{- if .Values.persistence.hostPath }}
+        - name: data
+          hostPath:
+            path: {{ .Values.persistence.hostPath }}
+            type: DirectoryOrCreate
+      {{- else }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/charts/bitcoind/values.yaml
+++ b/charts/bitcoind/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: lncm/bitcoind
+  repository: bboerst/lncm-bitcoind
   tag: ""
   pullPolicy: IfNotPresent
 
@@ -21,6 +21,16 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+extraEnv: {}
+# MALLOC_ARENA_MAX: 1
+
+# Few options for configuration...
+#  1. Send in configuration as "arguments:". This simply adds each option as an argument to ./bitcoind
+#  2. Specify the name of an "externalSecret:" that contains the contents of bitcoin.conf.
+#  3. Both of these can be used together and is useful for things that you want to keep secret, like rpc
+#     credentials. In this case, you would specify most configuration as "arguments" and rpc credentials
+#     in an externalSecret.
 
 arguments:
   # Send trace/debug info to console instead of debug.log file
@@ -71,6 +81,13 @@ arguments:
   # - -maxmempool=50
   # - -maxconnections=40
   # - -maxuploadtarget=5000
+
+# This secret gets mounted as bitcoin.conf. Use this example command to generate this secret:
+#
+#  kubectl create secret generic bitcoin-conf-secret --from-file=bitcoin.conf=/path/to/bitcoin.conf
+#
+# The above example would then use "bitcoin-conf-secret" in configExternalSecretName
+configExternalSecretName: ""
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
- Switching to forked version of upstream lncm repo to add latest bitcoin-core versions. Fork is here: https://github.com/bboerst/lncm-docker-bitcoind/. Upstream has an open PR. Will switch back to lncm once PR merges.
- Adding ability to specify portions of configuration in a secret file. This is useful for using with SOPS where you might want to encrypt rpc credentials.
- Fixing tcp port bug where it's possible to hit an issue when no port is specified.
- Adding extraEnv to set environment variables.