### PR TITLE
[fulcrum] Bumping to v1.11.1 and RPCPASSWORD refacctor

### DIFF
--- a/charts/fulcrum/Chart.yaml
+++ b/charts/fulcrum/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 type: application
 description: fulcrum helm chart
 name: fulcrum
-version: 0.1.7
+version: 0.1.8
 # renovate: image=cculianu/fulcrum
-appVersion: "v1.11.0"
+appVersion: "v1.11.1"

--- a/charts/fulcrum/README.md
+++ b/charts/fulcrum/README.md
@@ -1,6 +1,6 @@
 # fulcrum
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.11.0](https://img.shields.io/badge/AppVersion-v1.11.0-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.11.1](https://img.shields.io/badge/AppVersion-v1.11.1-informational?style=flat-square)
 
 fulcrum helm chart
 
@@ -10,7 +10,7 @@ fulcrum helm chart
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | arguments[0] | string | `"/data/config.toml"` |  |
-| config | string | `"# Example config: https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf\ndatadir = /data\nbitcoind = bitcoind:8332\nrpcuser = fulcrum\nrpcpassword = hunter1\n#rpccookie = /authcookie/.cookie\n"` |  |
+| config | string | `"# Example config: https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf\ndatadir = /data\nbitcoind = bitcoind:8332\nrpcuser = fulcrum\nrpcpassword = hunter1 # alternatively use the rpcPasswordEnvVarSecretName instead\n#rpccookie = /authcookie/.cookie\n"` |  |
 | cookiePersistence.enabled | bool | `false` |  |
 | cookiePersistence.existingClaim | string | `"bitcoin-core-authcookie"` |  |
 | extraManifests | list | `[]` |  |
@@ -33,6 +33,7 @@ fulcrum helm chart
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| rpcPasswordEnvVarSecretName | string | `""` |  |
 | securityContext | object | `{}` |  |
 | service.annotations | object | `{}` |  |
 | service.enabled | bool | `true` |  |

--- a/charts/fulcrum/templates/deployment.yaml
+++ b/charts/fulcrum/templates/deployment.yaml
@@ -60,6 +60,14 @@ spec:
           {{-  range .Values.arguments }}
             - {{ . }}
           {{- end }}
+          env:
+            {{- if .Values.rpcPasswordEnvVarSecretName }}
+            - name: RPCPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.rpcPasswordEnvVarSecretName }}
+                  key: RPCPASSWORD
+            {{- end }}
           ports:
             {{- range $port := .Values.service.ports.tcp }}
             - name: "{{ $port }}-tcp"

--- a/charts/fulcrum/values.yaml
+++ b/charts/fulcrum/values.yaml
@@ -19,8 +19,12 @@ config: |
   datadir = /data
   bitcoind = bitcoind:8332
   rpcuser = fulcrum
-  rpcpassword = hunter1
+  rpcpassword = hunter1 # alternatively use the rpcPasswordEnvVarSecretName instead
   #rpccookie = /authcookie/.cookie
+
+# Secret name containing RPCPASSWORD, created from:
+#  kubectl create secret generic thesecretname -n fulcrum-namespace --from-literal=RPCPASSWORD=thepasswordhere
+rpcPasswordEnvVarSecretName: ""
 
 ssl:
   enabled: false


### PR DESCRIPTION
- Bumps to v1.11.1
- Refactors rpcpassword to optionally store it inside of an external secret. This may be useful for using SOPS and encrypting your rpcpassword secret.