### PR TITLE
[mempool] Add envFrom for better secrets management

### DIFF
--- a/charts/mempool/Chart.lock
+++ b/charts/mempool/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 19.1.0
-digest: sha256:e9985a6ac00ee33910a00cb0d623052902036443060e92cac75dbe2679ead582
-generated: "2024-10-10T09:23:39.096090854Z"
+  version: 20.1.1
+digest: sha256:4aa4508acefd21d369d000e3821a3b5f79ff005c16959817ad902e18eddbcca0
+generated: "2024-11-28T19:26:07.821670213Z"

--- a/charts/mempool/Chart.yaml
+++ b/charts/mempool/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 description: A Helm chart for mempool
 name: mempool
-version: 0.1.9
+version: 0.1.10
 # renovate: image=mempool/frontend
 appVersion: "v3.0.1"
 dependencies:
 - name: mariadb
-  version: "19.1.0"
+  version: "20.1.1"
   repository: "https://charts.bitnami.com/bitnami"

--- a/charts/mempool/README.md
+++ b/charts/mempool/README.md
@@ -1,6 +1,6 @@
 # mempool
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
 
 A Helm chart for mempool
 
@@ -8,7 +8,7 @@ A Helm chart for mempool
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mariadb | 19.1.0 |
+| https://charts.bitnami.com/bitnami | mariadb | 20.1.1 |
 
 ## Values
 
@@ -17,7 +17,7 @@ A Helm chart for mempool
 | backend.affinity | object | `{}` |  |
 | backend.arguments | string | `nil` |  |
 | backend.coreRpcHost | string | `"bitcoind"` |  |
-| backend.coreRpcPassword | string | `"1234567890abcdefg"` |  |
+| backend.coreRpcPassword | string | `""` |  |
 | backend.coreRpcPort | int | `8332` |  |
 | backend.coreRpcUsername | string | `"mempool"` |  |
 | backend.env.BISQ_ENABLED | string | `"false"` |  |
@@ -25,6 +25,7 @@ A Helm chart for mempool
 | backend.env.LIQUID_ENABLED | string | `"false"` |  |
 | backend.env.MEMPOOL_POOLS_JSON_TREE_URL | string | `"https://api.github.com/repos/mempool/mining-pools/git/trees/master"` |  |
 | backend.env.MEMPOOL_POOLS_JSON_URL | string | `"https://raw.githubusercontent.com/mempool/mining-pools/master/pools-v2.json"` |  |
+| backend.envExternalSecretName | string | `"test"` |  |
 | backend.fullnameOverride | string | `""` |  |
 | backend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | backend.image.repository | string | `"mempool/backend"` |  |

--- a/charts/mempool/templates/backend-deployment.yaml
+++ b/charts/mempool/templates/backend-deployment.yaml
@@ -70,14 +70,22 @@ spec:
             - {{ . }}
           {{ end }}
           env:
+            {{- if .Values.backend.coreRpcHost }}
             - name: "CORE_RPC_HOST"
               value: "{{ .Values.backend.coreRpcHost }}"
+            {{- end }}
+            {{- if .Values.backend.coreRpcPort }}
             - name: "CORE_RPC_PORT"
               value: "{{ .Values.backend.coreRpcPort }}"
+            {{- end }}
+            {{- if .Values.backend.coreRpcUsername }}
             - name: "CORE_RPC_USERNAME"
               value: "{{ .Values.backend.coreRpcUsername }}"
+            {{- end }}
+            {{- if .Values.backend.coreRpcPassword }}
             - name: "CORE_RPC_PASSWORD"
               value: "{{ .Values.backend.coreRpcPassword }}"
+            {{- end }}
             - name: "DATABASE_ENABLED"
               value: "true"
             - name: "DATABASE_HOST"
@@ -108,6 +116,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+          {{- if .Values.backend.envExternalSecretName }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.backend.envExternalSecretName }}
+          {{- end }}
           ports:
             - name: "tcp"
               containerPort: {{ .Values.backend.service.tcpPort }}

--- a/charts/mempool/values.yaml
+++ b/charts/mempool/values.yaml
@@ -164,11 +164,19 @@ backend:
     BISQ_ENABLED: "false"
     LIQUID_ENABLED: "false"
     LIGHTNING: "false"
+  
+  # This secret can contain environment variables such as CORE_RPC_PASSWORD. Useful for using with a secrets manager like SOPS.
+  #
+  # Example:
+  #  kubectl create secret generic mempool-space-env-vars --from-literal=CORE_RPC_PASSWORD=thecoreprcpassword
+  #
+  # The above example would then use "mempool-space-env-vars" in envExternalSecretName
+  envExternalSecretName: "test"
 
   coreRpcHost: bitcoind
   coreRpcPort: 8332
   coreRpcUsername: mempool
-  coreRpcPassword: 1234567890abcdefg
+  coreRpcPassword: "" # Can also be set using envExternalSecretName above
   statisticsEnabled: true
 
   mempoolBackend:


### PR DESCRIPTION
Adding envFrom now makes it possible to add env vars to an existing secret. This makes it useful to manage secrets outside of the chart, for example with SOPS.