### PR TITLE
Fixing service naming for backend host

### DIFF
--- a/charts/mempool/Chart.yaml
+++ b/charts/mempool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for mempool
 name: mempool
-version: 0.1.10
+version: 0.1.11
 # renovate: image=mempool/frontend
 appVersion: "v3.0.1"
 dependencies:

--- a/charts/mempool/README.md
+++ b/charts/mempool/README.md
@@ -1,6 +1,6 @@
 # mempool
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
 
 A Helm chart for mempool
 

--- a/charts/mempool/templates/frontend-deployment.yaml
+++ b/charts/mempool/templates/frontend-deployment.yaml
@@ -60,7 +60,7 @@ spec:
           {{ end }}
           env:
             - name: "BACKEND_MAINNET_HTTP_HOST"
-              value: "{{ template "mempool.name" . }}-backend"
+              value: "{{ template "mempool.fullname" . }}-backend"
             - name: "FRONTEND_HTTP_PORT"
               value: "{{ .Values.frontend.service.tcpPort }}"
           {{- range $key, $val := .Values.frontend.env }}


### PR DESCRIPTION
Backend hostname was using .name instead of .fullname. Switching to .fullname to match actual service name.