### PR TITLE
Fixing mariadb naming

### DIFF
--- a/charts/mempool/Chart.yaml
+++ b/charts/mempool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for mempool
 name: mempool
-version: 0.1.11
+version: 0.1.12
 # renovate: image=mempool/frontend
 appVersion: "v3.0.1"
 dependencies:

--- a/charts/mempool/README.md
+++ b/charts/mempool/README.md
@@ -1,6 +1,6 @@
 # mempool
 
-![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
+![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
 
 A Helm chart for mempool
 

--- a/charts/mempool/templates/backend-deployment.yaml
+++ b/charts/mempool/templates/backend-deployment.yaml
@@ -56,7 +56,7 @@ spec:
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           command:
             - "./wait-for-it.sh"
-            - "{{ template "mempool.name" . }}-mariadb:3306"
+            - "{{ template "mempool.fullname" . }}-mariadb:3306"
             - "--timeout=720"
             - "--strict"
             - "--"
@@ -89,7 +89,7 @@ spec:
             - name: "DATABASE_ENABLED"
               value: "true"
             - name: "DATABASE_HOST"
-              value: "{{ template "mempool.name" . }}-mariadb"
+              value: "{{ template "mempool.fullname" . }}-mariadb"
             - name: "DATABASE_DATABASE"
               value: "{{ .Values.mariadb.auth.database }}"
             - name: "DATABASE_USERNAME"


### PR DESCRIPTION
Fixing naming for mariadb hostname. Was using .name instead of .fullname.