### PR TITLE
Bitcoind fix selectors

### DIFF
--- a/charts/bitcoind/Chart.yaml
+++ b/charts/bitcoind/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 description: A Helm chart for bitcoin-core daemon bitcoind
 name: bitcoind
-version: 0.3.4
+version: 0.3.5
 # renovate: image=bboerst/lncm-bitcoind
 appVersion: "v28.0-amd64"

--- a/charts/bitcoind/README.md
+++ b/charts/bitcoind/README.md
@@ -1,6 +1,6 @@
 # bitcoind
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![AppVersion: v28.0-amd64](https://img.shields.io/badge/AppVersion-v28.0--amd64-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![AppVersion: v28.0-amd64](https://img.shields.io/badge/AppVersion-v28.0--amd64-informational?style=flat-square)
 
 A Helm chart for bitcoin-core daemon bitcoind
 

--- a/charts/bitcoind/templates/deployment.yaml
+++ b/charts/bitcoind/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    app: {{ template "bitcoind.name" . }}
+    app: {{ template "bitcoind.fullname" . }}
     chart: {{ template "bitcoind.chart" . }}
     heritage: {{ .Release.Service }}
     {{ .Values.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: bitcoind
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "bitcoind.name" . }}
+      app: {{ template "bitcoind.fullname" . }}
     {{- if .Values.useComponentLabel }}
       {{ .Values.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: bitcoind
     {{- end }}
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       {{- end }}
       labels:
-        app: {{ template "bitcoind.name" . }}
+        app: {{ template "bitcoind.fullname" . }}
         component: "{{ .Values.name }}"
         {{ .Values.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: bitcoind
         {{- if .Values.podLabels }}

--- a/charts/bitcoind/templates/service.yaml
+++ b/charts/bitcoind/templates/service.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
-    app: {{ template "bitcoind.name" . }}
+    app: {{ template "bitcoind.fullname" . }}
     chart: {{ template "bitcoind.chart" . }}
     component: "{{ .Values.name }}"
     heritage: {{ .Release.Service }}
@@ -87,7 +87,7 @@ spec:
      {{- end }}
   {{- end }}
   selector:
-    app: {{ template "bitcoind.name" . }}
+    app: {{ template "bitcoind.fullname" . }}
     {{ .Values.componentLabelKeyOverride | default "app.kubernetes.io/component" }}: bitcoind
   type: "{{ .Values.service.type }}"
 {{- end }}


### PR DESCRIPTION
Currently not possible to run multiple node instances in same namespace because selectors are not unique. Fixing this.