### PR TITLE
[mempool] Use shared db server for multiple backends

### DIFF
--- a/charts/mempool/Chart.yaml
+++ b/charts/mempool/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for mempool
 name: mempool
-version: 0.1.15
+version: 0.1.16
 # renovate: image=mempool/frontend
 appVersion: "v3.0.1"
 dependencies:

--- a/charts/mempool/README.md
+++ b/charts/mempool/README.md
@@ -1,6 +1,6 @@
 # mempool
 
-![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
+![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square) ![AppVersion: v3.0.1](https://img.shields.io/badge/AppVersion-v3.0.1-informational?style=flat-square)
 
 A Helm chart for mempool
 
@@ -56,7 +56,7 @@ A Helm chart for mempool
 | backends[0].tolerations | list | `[]` |  |
 | frontend.affinity | object | `{}` |  |
 | frontend.arguments | string | `nil` |  |
-| frontend.env.BACKEND_MAINNET_HTTP_HOST | string | `"mempool-space-mainnet-backend-mainnet"` |  |
+| frontend.env.BACKEND_MAINNET_HTTP_HOST | string | `"mempool-backend-mainnet"` |  |
 | frontend.fullnameOverride | string | `""` |  |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | frontend.image.repository | string | `"mempool/frontend"` |  |
@@ -97,6 +97,7 @@ A Helm chart for mempool
 | mariadb.auth.password | string | `"mempool"` |  |
 | mariadb.auth.rootPassword | string | `"admin"` |  |
 | mariadb.auth.username | string | `"mempool"` |  |
+| mariadb.initdbScripts."create_databases.sql" | string | `"CREATE DATABASE IF NOT EXISTS mainnet;\nGRANT ALL PRIVILEGES ON mainnet.* TO 'mempool'@'%';\n\n# CREATE DATABASE IF NOT EXISTS testnet;\n# GRANT ALL PRIVILEGES ON testnet.* TO 'mempool'@'%';\nFLUSH PRIVILEGES;"` |  |
 | mariadb.primary.persistence.enabled | bool | `false` |  |
 | mariadb.primary.persistence.size | string | `"8Gi"` |  |
 | mariadb.primary.resourcesPreset | string | `"small"` |  |

--- a/charts/mempool/templates/backend-deployment.yaml
+++ b/charts/mempool/templates/backend-deployment.yaml
@@ -96,7 +96,7 @@ spec:
             - name: "DATABASE_HOST"
               value: "{{ template "mempool.fullname" $root }}-mariadb"
             - name: "DATABASE_DATABASE"
-              value: "{{ $.Values.mariadb.auth.database }}"
+              value: "{{ $backend.name }}"
             - name: "DATABASE_USERNAME"
               value: "{{ $.Values.mariadb.auth.username }}"
             - name: "DATABASE_PASSWORD"

--- a/charts/mempool/values.yaml
+++ b/charts/mempool/values.yaml
@@ -146,6 +146,7 @@ frontend:
   affinity: {}
 
 backends:
+# Ensure that a database is created for each backend 'name' in the mariadb.initdbScripts below
   - name: mainnet
     image:
       repository: mempool/backend

--- a/charts/mempool/values.yaml
+++ b/charts/mempool/values.yaml
@@ -24,7 +24,7 @@ frontend:
   fullnameOverride: ""
 
   env:
-    BACKEND_MAINNET_HTTP_HOST: "mempool-space-mainnet-backend-mainnet"
+    BACKEND_MAINNET_HTTP_HOST: "mempool-backend-mainnet"
 
   arguments:
     # Send trace/debug info to console instead of debug.log file
@@ -255,6 +255,16 @@ mariadb:
     username: mempool
     password: mempool
     rootPassword: admin
+
+  # Ensure that a database is created for each backend 'name' in the backends list
+  initdbScripts:
+    create_databases.sql: |-
+      CREATE DATABASE IF NOT EXISTS mainnet;
+      GRANT ALL PRIVILEGES ON mainnet.* TO 'mempool'@'%';
+      
+      # CREATE DATABASE IF NOT EXISTS testnet;
+      # GRANT ALL PRIVILEGES ON testnet.* TO 'mempool'@'%';
+      FLUSH PRIVILEGES;
 
   primary:
     resourcesPreset: "small"


### PR DESCRIPTION
Bugfix where having multiple backends causes data overlap. Each backend needs its own database within the mariadb server.